### PR TITLE
Codex attempt at implementing valid type annotations for `testfixtures.datetime`

### DIFF
--- a/testfixtures/tests/test_date.py
+++ b/testfixtures/tests/test_date.py
@@ -15,24 +15,24 @@ class TestDate(TestCase):
     #     greatfully received!
 
     @replace('datetime.date', mock_date())
-    def test_today(self):
+    def test_today(self) -> None:
         from datetime import date
         compare(date.today(), d(2001, 1, 1))
         compare(date.today(), d(2001, 1, 2))
         compare(date.today(), d(2001, 1, 4))
 
     @replace('datetime.date', mock_date(2001, 2, 3))
-    def test_today_supplied(self):
+    def test_today_supplied(self) -> None:
         from datetime import date
         compare(date.today(), d(2001, 2, 3))
 
     @replace('datetime.date', mock_date(year=2001, month=2, day=3))
-    def test_today_all_kw(self):
+    def test_today_all_kw(self) -> None:
         from datetime import date
         compare(date.today(), d(2001, 2, 3))
 
     @replace('datetime.date', mock_date(None))
-    def test_today_sequence(self, t: type[MockDate]):
+    def test_today_sequence(self, t: type[MockDate]) -> None:
         t.add(2002, 1, 1)
         t.add(2002, 1, 2)
         t.add(2002, 1, 3)
@@ -42,7 +42,7 @@ class TestDate(TestCase):
         compare(date.today(), d(2002, 1, 3))
 
     @replace('datetime.date', mock_date(None))
-    def test_today_requested_longer_than_supplied(self, t: type[MockDate]):
+    def test_today_requested_longer_than_supplied(self, t: type[MockDate]) -> None:
         t.add(2002, 1, 1)
         t.add(2002, 1, 2)
         from datetime import date
@@ -52,40 +52,41 @@ class TestDate(TestCase):
         compare(date.today(), d(2002, 1, 5))
 
     @replace('datetime.date', mock_date(None))
-    def test_add_date_supplied(self):
+    def test_add_date_supplied(self) -> None:
         from datetime import date
-        date = cast(type[MockDate], date)
-        date.add(d(2001, 1, 2))
-        date.add(date(2001, 1, 3))
+        date_cls = cast(type[MockDate], date)
+        date_cls.add(d(2001, 1, 2))
+        date_cls.add(date(2001, 1, 3))
         compare(date.today(), d(2001, 1, 2))
         compare(date.today(), d(2001, 1, 3))
 
-    def test_instantiate_with_date(self):
+    def test_instantiate_with_date(self) -> None:
         from datetime import date
         t = mock_date(date(2002, 1, 1))
         compare(t.today(), d(2002, 1, 1))
 
     @replace('datetime.date', mock_date(strict=True))
-    def test_call(self, t: type[MockDate]):
+    def test_call(self, t: type[MockDate]) -> None:
         compare(t(2002, 1, 2), d(2002, 1, 2))
         from datetime import date
         dt = date(2003, 2, 1)
         self.assertFalse(dt.__class__ is d)
         compare(dt, d(2003, 2, 1))
 
-    def test_gotcha_import(self):
+    def test_gotcha_import(self) -> None:
         # standard `replace` caveat, make sure you
         # patch all revelent places where date
         # has been imported:
 
         @replace('datetime.date', mock_date())
-        def test_something():
+        def test_something1() -> None:
             from datetime import date
             compare(date.today(), d(2001, 1, 1))
             compare(sample1.str_today_1(), '2001-01-02')
 
         with ShouldRaise(AssertionError) as s:
-            test_something()
+            test_something1()
+        assert s.raised is not None
         # This convoluted check is because we can't stub
         # out the date, since we're testing stubbing out
         # the date ;-)
@@ -97,22 +98,23 @@ class TestDate(TestCase):
 
         # What you need to do is replace the imported type:
         @replace('testfixtures.tests.sample1.date', mock_date())
-        def test_something():
+        def test_something2() -> None:
             compare(sample1.str_today_1(), '2001-01-01')
 
-        test_something()
+        test_something2()
 
-    def test_gotcha_import_and_obtain(self):
+    def test_gotcha_import_and_obtain(self) -> None:
         # Another gotcha is where people have locally obtained
         # a class attributes, where the normal patching doesn't
         # work:
 
         @replace('testfixtures.tests.sample1.date', mock_date())
-        def test_something():
+        def test_something3() -> None:
             compare(sample1.str_today_2(), '2001-01-01')
 
         with ShouldRaise(AssertionError) as s:
-            test_something()
+            test_something3()
+        assert s.raised is not None
         # This convoluted check is because we can't stub
         # out the date, since we're testing stubbing out
         # the date ;-)
@@ -124,15 +126,15 @@ class TestDate(TestCase):
 
         # What you need to do is replace the imported name:
         @replace('testfixtures.tests.sample1.today', mock_date().today)
-        def test_something():
+        def test_something4() -> None:
             compare(sample1.str_today_2(), '2001-01-01')
 
-        test_something()
+        test_something4()
 
     # if you have an embedded `today` as above, *and* you need to supply
     # a list of required dates, then it's often simplest just to
     # do a manual try-finally with a replacer:
-    def test_import_and_obtain_with_lists(self):
+    def test_import_and_obtain_with_lists(self) -> None:
 
         t = mock_date(None)
         t.add(2002, 1, 1)
@@ -148,78 +150,78 @@ class TestDate(TestCase):
             r.restore()
 
     @replace('datetime.date', mock_date())
-    def test_repr(self):
+    def test_repr(self) -> None:
         from datetime import date
         compare(repr(date), "<class 'testfixtures.datetime.MockDate'>")
 
     @replace('datetime.date', mock_date(delta=2))
-    def test_delta(self):
+    def test_delta(self) -> None:
         from datetime import date
         compare(date.today(), d(2001, 1, 1))
         compare(date.today(), d(2001, 1, 3))
         compare(date.today(), d(2001, 1, 5))
 
     @replace('datetime.date', mock_date(delta_type='weeks'))
-    def test_delta_type(self):
+    def test_delta_type(self) -> None:
         from datetime import date
         compare(date.today(), d(2001, 1, 1))
         compare(date.today(), d(2001, 1, 8))
         compare(date.today(), d(2001, 1, 22))
 
     @replace('datetime.date', mock_date(None))
-    def test_set(self):
+    def test_set(self) -> None:
         from datetime import date
-        date = cast(type[MockDate], date)
-        date.set(2001, 1, 2)
+        date_cls = cast(type[MockDate], date)
+        date_cls.set(2001, 1, 2)
         compare(date.today(), d(2001, 1, 2))
-        date.set(2002, 1, 1)
+        date_cls.set(2002, 1, 1)
         compare(date.today(), d(2002, 1, 1))
         compare(date.today(), d(2002, 1, 3))
 
     @replace('datetime.date', mock_date(None))
-    def test_set_date_supplied(self):
+    def test_set_date_supplied(self) -> None:
         from datetime import date
-        date = cast(type[MockDate], date)
-        date.set(d(2001, 1, 2))
+        date_cls = cast(type[MockDate], date)
+        date_cls.set(d(2001, 1, 2))
         compare(date.today(), d(2001, 1, 2))
-        date.set(date(2001, 1, 3))
+        date_cls.set(date(2001, 1, 3))
         compare(date.today(), d(2001, 1, 3))
 
     @replace('datetime.date', mock_date(None))
-    def test_set_kw(self):
+    def test_set_kw(self) -> None:
         from datetime import date
-        date = cast(type[MockDate], date)
-        date.set(year=2001, month=1, day=2)
+        date_cls = cast(type[MockDate], date)
+        date_cls.set(year=2001, month=1, day=2)
         compare(date.today(), d(2001, 1, 2))
 
     @replace('datetime.date', mock_date(None))
-    def test_add_kw(self, t: type[MockDate]):
+    def test_add_kw(self, t: type[MockDate]) -> None:
         t.add(year=2002, month=1, day=1)
         from datetime import date
         compare(date.today(), d(2002, 1, 1))
 
     @replace('datetime.date', mock_date(strict=True))
-    def test_isinstance_strict_true(self):
+    def test_isinstance_strict_true(self) -> None:
         from datetime import date
-        date = cast(type[MockDate], date)
-        to_check = []
-        to_check.append(date(1999, 1, 1))
-        to_check.append(date.today())
-        date.set(2001, 1, 2)
-        to_check.append(date.today())
-        date.add(2001, 1, 3)
-        to_check.append(date.today())
-        to_check.append(date.today())
-        date.set(date(2001, 1, 4))
-        to_check.append(date.today())
-        date.add(date(2001, 1, 5))
-        to_check.append(date.today())
-        to_check.append(date.today())
-        date.set(d(2001, 1, 4))
-        to_check.append(date.today())
-        date.add(d(2001, 1, 5))
-        to_check.append(date.today())
-        to_check.append(date.today())
+        date_cls = cast(type[MockDate], date)
+        to_check: list[date] = []
+        to_check.append(date_cls(1999, 1, 1))
+        to_check.append(date_cls.today())
+        date_cls.set(2001, 1, 2)
+        to_check.append(date_cls.today())
+        date_cls.add(2001, 1, 3)
+        to_check.append(date_cls.today())
+        to_check.append(date_cls.today())
+        date_cls.set(date(2001, 1, 4))
+        to_check.append(date_cls.today())
+        date_cls.add(date(2001, 1, 5))
+        to_check.append(date_cls.today())
+        to_check.append(date_cls.today())
+        date_cls.set(d(2001, 1, 4))
+        to_check.append(date_cls.today())
+        date_cls.add(d(2001, 1, 5))
+        to_check.append(date_cls.today())
+        to_check.append(date_cls.today())
 
         for inst in to_check:
             self.assertTrue(isinstance(inst, date), inst)
@@ -227,50 +229,50 @@ class TestDate(TestCase):
             self.assertTrue(isinstance(inst, d), inst)
             self.assertFalse(inst.__class__ is d, inst)
 
-    def test_strict_addition(self):
+    def test_strict_addition(self) -> None:
         mock_d = mock_date(strict=True)
         dt = mock_d(2001, 1, 1) + timedelta(days=1)
         assert type(dt) is mock_d
 
-    def test_non_strict_addition(self):
+    def test_non_strict_addition(self) -> None:
         from datetime import date
         mock_d = mock_date(strict=False)
         dt = mock_d(2001, 1, 1) + timedelta(days=1)
         assert type(dt) is date
 
-    def test_strict_add(self):
+    def test_strict_add(self) -> None:
         mock_d = mock_date(None, strict=True)
         mock_d.add(2001, 1, 1)
         assert type(mock_d.today()) is mock_d
 
-    def test_non_strict_add(self):
+    def test_non_strict_add(self) -> None:
         from datetime import date
         mock_d = mock_date(None, strict=False)
         mock_d.add(2001, 1, 1)
         assert type(mock_d.today()) is date
 
     @replace('datetime.date', mock_date())
-    def test_isinstance_default(self):
+    def test_isinstance_default(self) -> None:
         from datetime import date
-        date = cast(type[MockDate], date)
-        to_check = []
-        to_check.append(date(1999, 1, 1))
-        to_check.append(date.today())
-        date.set(2001, 1, 2)
-        to_check.append(date.today())
-        date.add(2001, 1, 3)
-        to_check.append(date.today())
-        to_check.append(date.today())
-        date.set(date(2001, 1, 4))
-        to_check.append(date.today())
-        date.add(date(2001, 1, 5))
-        to_check.append(date.today())
-        to_check.append(date.today())
-        date.set(d(2001, 1, 4))
-        to_check.append(date.today())
-        date.add(d(2001, 1, 5))
-        to_check.append(date.today())
-        to_check.append(date.today())
+        date_cls = cast(type[MockDate], date)
+        to_check: list[date] = []
+        to_check.append(date_cls(1999, 1, 1))
+        to_check.append(date_cls.today())
+        date_cls.set(2001, 1, 2)
+        to_check.append(date_cls.today())
+        date_cls.add(2001, 1, 3)
+        to_check.append(date_cls.today())
+        to_check.append(date_cls.today())
+        date_cls.set(date(2001, 1, 4))
+        to_check.append(date_cls.today())
+        date_cls.add(date(2001, 1, 5))
+        to_check.append(date_cls.today())
+        to_check.append(date_cls.today())
+        date_cls.set(d(2001, 1, 4))
+        to_check.append(date_cls.today())
+        date_cls.add(d(2001, 1, 5))
+        to_check.append(date_cls.today())
+        to_check.append(date_cls.today())
 
         for inst in to_check:
             self.assertFalse(isinstance(inst, date), inst)
@@ -278,36 +280,36 @@ class TestDate(TestCase):
             self.assertTrue(isinstance(inst, d), inst)
             self.assertTrue(inst.__class__ is d, inst)
 
-    def test_tick_when_static(self):
+    def test_tick_when_static(self) -> None:
         date = mock_date(delta=0)
         compare(date.today(), expected=d(2001, 1, 1))
         date.tick(days=1)
         compare(date.today(), expected=d(2001, 1, 2))
 
-    def test_tick_when_dynamic(self):
+    def test_tick_when_dynamic(self) -> None:
         # hopefully not that common?
         date = mock_date()
         compare(date.today(), expected=date(2001, 1, 1))
         date.tick(days=1)
         compare(date.today(), expected=date(2001, 1, 3))
 
-    def test_tick_with_timedelta_instance(self):
+    def test_tick_with_timedelta_instance(self) -> None:
         date = mock_date(delta=0)
         compare(date.today(), expected=d(2001, 1, 1))
         date.tick(timedelta(days=1))
         compare(date.today(), expected=d(2001, 1, 2))
 
-    def test_old_import(self):
+    def test_old_import(self) -> None:
         from testfixtures import test_date
         assert test_date is mock_date
 
-    def test_add_timedelta_not_strict(self):
+    def test_add_timedelta_not_strict(self) -> None:
         mock_class = mock_date()
         value = mock_class.today() + timedelta(days=1)
         assert isinstance(value, date)
         assert type(value) is date
 
-    def test_add_timedelta_strict(self):
+    def test_add_timedelta_strict(self) -> None:
         mock_class = mock_date(strict=True)
         value = mock_class.today() + timedelta(days=1)
         assert isinstance(value, date)

--- a/testfixtures/tests/test_datetime.py
+++ b/testfixtures/tests/test_datetime.py
@@ -16,10 +16,10 @@ class SampleTZInfo(tzinfo):
     def tzname(self, dt: datetime | None) -> str:
         return "SAMPLE"
 
-    def utcoffset(self, dt):
+    def utcoffset(self, dt: datetime | None) -> timedelta:
         return timedelta(minutes=3) + self.dst(dt)
 
-    def dst(self, dt):
+    def dst(self, dt: datetime | None) -> timedelta:
         return timedelta(minutes=1)
 
 
@@ -28,10 +28,10 @@ class SampleTZInfo2(tzinfo):
     def tzname(self, dt: datetime | None) -> str:
         return "SAMPLE2"
 
-    def utcoffset(self, dt):
+    def utcoffset(self, dt: datetime | None) -> timedelta:
         return timedelta(minutes=5)
 
-    def dst(self, dt):
+    def dst(self, dt: datetime | None) -> timedelta:
         return timedelta(minutes=0)
 
 
@@ -40,14 +40,14 @@ class WeirdTZInfo(tzinfo):
     def tzname(self, dt: datetime | None) -> str:
         return "WEIRD"
 
-    def utcoffset(self, dt):
+    def utcoffset(self, dt: datetime | None) -> timedelta | None:
         return None
 
-    def dst(self, dt):
+    def dst(self, dt: datetime | None) -> timedelta | None:
         return None
 
 
-def test_sample_tzinfos():
+def test_sample_tzinfos() -> None:
     compare(SampleTZInfo().tzname(None), expected='SAMPLE')
     compare(SampleTZInfo2().tzname(None), expected='SAMPLE2')
     compare(WeirdTZInfo().tzname(None), expected='WEIRD')
@@ -58,62 +58,62 @@ def test_sample_tzinfos():
 class TestDateTime(TestCase):
 
     @replace('datetime.datetime', mock_datetime())
-    def test_now(self):
+    def test_now(self) -> None:
         from datetime import datetime
         compare(datetime.now(), d(2001, 1, 1, 0, 0, 0))
         compare(datetime.now(), d(2001, 1, 1, 0, 0, 10))
         compare(datetime.now(), d(2001, 1, 1, 0, 0, 30))
 
     @replace('datetime.datetime', mock_datetime())
-    def test_now_with_tz_supplied(self):
+    def test_now_with_tz_supplied(self) -> None:
         from datetime import datetime
         info = SampleTZInfo()
         compare(datetime.now(info), d(2001, 1, 1, 0, 4, tzinfo=SampleTZInfo()))
 
     @replace('datetime.datetime', mock_datetime(tzinfo=SampleTZInfo()))
-    def test_now_with_tz_setup(self):
+    def test_now_with_tz_setup(self) -> None:
         from datetime import datetime
         compare(datetime.now(), d(2001, 1, 1))
 
     @replace('datetime.datetime', mock_datetime(tzinfo=WeirdTZInfo()))
-    def test_now_with_werid_tz_setup(self):
+    def test_now_with_werid_tz_setup(self) -> None:
         from datetime import datetime
         with ShouldRaise(TypeError('tzinfo with .utcoffset() returning None is not supported')):
             datetime.now(tz=SampleTZInfo())
 
     @replace('datetime.datetime', mock_datetime(tzinfo=SampleTZInfo()))
-    def test_now_with_tz_setup_and_supplied(self):
+    def test_now_with_tz_setup_and_supplied(self) -> None:
         from datetime import datetime
         info = SampleTZInfo2()
         compare(datetime.now(info), d(2001, 1, 1, 0, 1, tzinfo=info))
 
     @replace('datetime.datetime', mock_datetime(tzinfo=SampleTZInfo()))
-    def test_now_with_tz_setup_and_same_supplied(self):
+    def test_now_with_tz_setup_and_same_supplied(self) -> None:
         from datetime import datetime
         info = SampleTZInfo()
         compare(datetime.now(info), d(2001, 1, 1, tzinfo=info))
 
-    def test_now_with_tz_instance(self):
+    def test_now_with_tz_instance(self) -> None:
         dt = mock_datetime(d(2001, 1, 1, tzinfo=SampleTZInfo()))
         compare(dt.now(), d(2001, 1, 1))
 
-    def test_now_with_tz_instance_and_supplied(self):
+    def test_now_with_tz_instance_and_supplied(self) -> None:
         dt = mock_datetime(d(2001, 1, 1, tzinfo=SampleTZInfo()))
         info = SampleTZInfo2()
         compare(dt.now(info), d(2001, 1, 1, 0, 1, tzinfo=info))
 
-    def test_now_with_tz_instance_and_same_supplied(self):
+    def test_now_with_tz_instance_and_same_supplied(self) -> None:
         dt = mock_datetime(d(2001, 1, 1, tzinfo=SampleTZInfo()))
         info = SampleTZInfo()
         compare(dt.now(info), d(2001, 1, 1, tzinfo=info))
 
     @replace('datetime.datetime', mock_datetime(2002, 1, 1, 1, 2, 3))
-    def test_now_supplied(self):
+    def test_now_supplied(self) -> None:
         from datetime import datetime
         compare(datetime.now(), d(2002, 1, 1, 1, 2, 3))
 
     @replace('datetime.datetime', mock_datetime(None))
-    def test_now_sequence(self, t):
+    def test_now_sequence(self, t: type[MockDateTime]) -> None:
         t.add(2002, 1, 1, 1, 0, 0)
         t.add(2002, 1, 1, 2, 0, 0)
         t.add(2002, 1, 1, 3, 0, 0)
@@ -123,7 +123,7 @@ class TestDateTime(TestCase):
         compare(datetime.now(), d(2002, 1, 1, 3, 0, 0))
 
     @replace('datetime.datetime', mock_datetime())
-    def test_add_and_set(self, t):
+    def test_add_and_set(self, t: type[MockDateTime]) -> None:
         t.add(2002, 1, 1, 1, 0, 0)
         t.add(2002, 1, 1, 2, 0, 0)
         t.set(2002, 1, 1, 3, 0, 0)
@@ -133,7 +133,7 @@ class TestDateTime(TestCase):
         compare(datetime.now(), d(2002, 1, 1, 3, 0, 30))
 
     @replace('datetime.datetime', mock_datetime(None))
-    def test_add_datetime_supplied(self, t: type[MockDateTime]):
+    def test_add_datetime_supplied(self, t: type[MockDateTime]) -> None:
         from datetime import datetime
         t.add(d(2002, 1, 1, 1))
         t.add(datetime(2002, 1, 1, 2))
@@ -147,13 +147,13 @@ class TestDateTime(TestCase):
             ))):
             t.add(d(2001, 1, 1, tzinfo=tzinfo))
 
-    def test_instantiate_with_datetime(self):
+    def test_instantiate_with_datetime(self) -> None:
         from datetime import datetime
         t = mock_datetime(datetime(2002, 1, 1, 1))
         compare(t.now(), d(2002, 1, 1, 1, 0, 0))
 
     @replace('datetime.datetime', mock_datetime(None))
-    def test_now_requested_longer_than_supplied(self, t: type[MockDateTime]):
+    def test_now_requested_longer_than_supplied(self, t: type[MockDateTime]) -> None:
         t.add(2002, 1, 1, 1, 0, 0)
         t.add(2002, 1, 1, 2, 0, 0)
         from datetime import datetime
@@ -163,14 +163,14 @@ class TestDateTime(TestCase):
         compare(datetime.now(), d(2002, 1, 1, 2, 0, 30))
 
     @replace('datetime.datetime', mock_datetime(strict=True))
-    def test_call(self, t: type[MockDateTime]):
+    def test_call(self, t: type[MockDateTime]) -> None:
         compare(t(2002, 1, 2, 3, 4, 5), d(2002, 1, 2, 3, 4, 5))
         from datetime import datetime
         dt = datetime(2001, 1, 1, 1, 0, 0)
         self.assertFalse(dt.__class__ is d)
         compare(dt, d(2001, 1, 1, 1, 0, 0))
 
-    def test_date_return_type(self):
+    def test_date_return_type(self) -> None:
         with Replacer() as r:
             r.replace('datetime.datetime', mock_datetime())
             from datetime import datetime
@@ -179,7 +179,7 @@ class TestDateTime(TestCase):
             compare(d, date(2001, 1, 1))
             self.assertTrue(d.__class__ is date)
 
-    def test_date_return_type_picky(self):
+    def test_date_return_type_picky(self) -> None:
         # type checking is a bitch :-/
         date_type = mock_date(strict=True)
         with Replacer() as r:
@@ -195,7 +195,7 @@ class TestDateTime(TestCase):
     # if you have an embedded `now` as above, *and* you need to supply
     # a list of required datetimes, then it's often simplest just to
     # do a manual try-finally with a replacer:
-    def test_import_and_obtain_with_lists(self):
+    def test_import_and_obtain_with_lists(self) -> None:
 
         t = mock_datetime(None)
         t.add(2002, 1, 1, 1, 0, 0)
@@ -211,36 +211,36 @@ class TestDateTime(TestCase):
             r.restore()
 
     @replace('datetime.datetime', mock_datetime())
-    def test_repr(self):
+    def test_repr(self) -> None:
         from datetime import datetime
         compare(repr(datetime), "<class 'testfixtures.datetime.MockDateTime'>")
 
     @replace('datetime.datetime', mock_datetime(delta=1))
-    def test_delta(self):
+    def test_delta(self) -> None:
         from datetime import datetime
         compare(datetime.now(), d(2001, 1, 1, 0, 0, 0))
         compare(datetime.now(), d(2001, 1, 1, 0, 0, 1))
         compare(datetime.now(), d(2001, 1, 1, 0, 0, 2))
 
     @replace('datetime.datetime', mock_datetime(delta_type='minutes'))
-    def test_delta_type(self):
+    def test_delta_type(self) -> None:
         from datetime import datetime
         compare(datetime.now(), d(2001, 1, 1, 0, 0, 0))
         compare(datetime.now(), d(2001, 1, 1, 0, 10, 0))
         compare(datetime.now(), d(2001, 1, 1, 0, 30, 0))
 
     @replace('datetime.datetime', mock_datetime(None))
-    def test_set(self):
+    def test_set(self) -> None:
         from datetime import datetime
-        datetime = cast(type[MockDateTime], datetime)
-        datetime.set(2001, 1, 1, 1, 0, 1)
+        dt_class = cast(type[MockDateTime], datetime)
+        dt_class.set(2001, 1, 1, 1, 0, 1)
         compare(datetime.now(), d(2001, 1, 1, 1, 0, 1))
-        datetime.set(2002, 1, 1, 1, 0, 0)
+        dt_class.set(2002, 1, 1, 1, 0, 0)
         compare(datetime.now(), d(2002, 1, 1, 1, 0, 0))
         compare(datetime.now(), d(2002, 1, 1, 1, 0, 20))
 
     @replace('datetime.datetime', mock_datetime(None))
-    def test_set_datetime_supplied(self, t: type[MockDateTime]):
+    def test_set_datetime_supplied(self, t: type[MockDateTime]) -> None:
         from datetime import datetime
         t.set(d(2002, 1, 1, 1))
         compare(datetime.now(), d(2002, 1, 1, 1, 0, 0))
@@ -255,57 +255,57 @@ class TestDateTime(TestCase):
             t.set(d(2001, 1, 1, tzinfo=tzinfo))
 
     @replace('datetime.datetime', mock_datetime(None, tzinfo=SampleTZInfo()))
-    def test_set_tz_setup(self):
+    def test_set_tz_setup(self) -> None:
         from datetime import datetime
-        datetime = cast(type[MockDateTime], datetime)
-        datetime.set(year=2002, month=1, day=1)
+        dt_class = cast(type[MockDateTime], datetime)
+        dt_class.set(year=2002, month=1, day=1)
         compare(datetime.now(), d(2002, 1, 1))
 
     @replace('datetime.datetime', mock_datetime(None))
-    def test_set_kw(self):
+    def test_set_kw(self) -> None:
         from datetime import datetime
-        datetime = cast(type[MockDateTime], datetime)
-        datetime.set(year=2002, month=1, day=1)
+        dt_class = cast(type[MockDateTime], datetime)
+        dt_class.set(year=2002, month=1, day=1)
         compare(datetime.now(), d(2002, 1, 1))
 
     @replace('datetime.datetime', mock_datetime(None))
-    def test_set_tzinfo_kw(self):
+    def test_set_tzinfo_kw(self) -> None:
         from datetime import datetime
-        datetime = cast(type[MockDateTime], datetime)
+        dt_class = cast(type[MockDateTime], datetime)
         with ShouldRaise(TypeError('Cannot add using tzinfo on MockDateTime')):
-            datetime.set(year=2002, month=1, day=1, tzinfo=SampleTZInfo())
+            dt_class.set(year=2002, month=1, day=1, tzinfo=SampleTZInfo())
 
     @replace('datetime.datetime', mock_datetime(None))
-    def test_set_tzinfo_args(self):
+    def test_set_tzinfo_args(self) -> None:
         from datetime import datetime
-        datetime = cast(type[MockDateTime], datetime)
+        dt_class = cast(type[MockDateTime], datetime)
         with ShouldRaise(TypeError('Cannot add using tzinfo on MockDateTime')):
-            datetime.set(2002, 1, 2, 3, 4, 5, 6, SampleTZInfo())
+            dt_class.set(2002, 1, 2, 3, 4, 5, 6, SampleTZInfo())
 
     @replace('datetime.datetime', mock_datetime(None))
-    def test_add_kw(self, t: type[MockDateTime]):
+    def test_add_kw(self, t: type[MockDateTime]) -> None:
         from datetime import datetime
         t.add(year=2002, day=1, month=1)
         compare(datetime.now(), d(2002, 1, 1))
 
     @replace('datetime.datetime', mock_datetime(None))
-    def test_add_tzinfo_kw(self, t: type[MockDateTime]):
+    def test_add_tzinfo_kw(self, t: type[MockDateTime]) -> None:
         with ShouldRaise(TypeError('Cannot add using tzinfo on MockDateTime')):
             t.add(year=2002, month=1, day=1, tzinfo=SampleTZInfo())
 
     @replace('datetime.datetime', mock_datetime(None))
-    def test_add_tzinfo_args(self, t: type[MockDateTime]):
+    def test_add_tzinfo_args(self, t: type[MockDateTime]) -> None:
         with ShouldRaise(TypeError('Cannot add using tzinfo on MockDateTime')):
             t.add(2002, 1, 2, 3, 4, 5, 6, SampleTZInfo())
 
     @replace('datetime.datetime',
              mock_datetime(2001, 1, 2, 3, 4, 5, 6, SampleTZInfo()))
-    def test_max_number_args(self):
+    def test_max_number_args(self) -> None:
         from datetime import datetime
         compare(datetime.now(), d(2001, 1, 2, 3, 4, 5, 6))
 
     @replace('datetime.datetime', mock_datetime(2001, 1, 2))
-    def test_min_number_args(self):
+    def test_min_number_args(self) -> None:
         from datetime import datetime
         compare(datetime.now(), d(2001, 1, 2))
 
@@ -319,48 +319,48 @@ class TestDateTime(TestCase):
         microsecond=6,
         tzinfo=SampleTZInfo()
         ))
-    def test_all_kw(self):
+    def test_all_kw(self) -> None:
         from datetime import datetime
         compare(datetime.now(), d(2001, 1, 2, 3, 4, 5, 6))
 
     @replace('datetime.datetime', mock_datetime(2001, 1, 2))
-    def test_utc_now(self):
+    def test_utc_now(self) -> None:
         from datetime import datetime
         compare(datetime.utcnow(), d(2001, 1, 2))
 
     @replace('datetime.datetime',
              mock_datetime(2001, 1, 2, tzinfo=SampleTZInfo()))
-    def test_utc_now_with_tz(self):
+    def test_utc_now_with_tz(self) -> None:
         from datetime import datetime
         compare(datetime.utcnow(), d(2001, 1, 1, 23, 56))
 
     @replace('datetime.datetime', mock_datetime(strict=True))
-    def test_isinstance_strict(self):
+    def test_isinstance_strict(self) -> None:
         from datetime import datetime
-        datetime = cast(type[MockDateTime], datetime)
-        to_check = []
-        to_check.append(datetime(1999, 1, 1))
-        to_check.append(datetime.now())
-        to_check.append(datetime.now(SampleTZInfo()))
-        to_check.append(datetime.utcnow())
-        datetime.set(2001, 1, 1, 20)
-        to_check.append(datetime.now())
-        datetime.add(2001, 1, 1, 21)
-        to_check.append(datetime.now())
-        to_check.append(datetime.now())
-        datetime.set(datetime(2001, 1, 1, 22))
-        to_check.append(datetime.now())
-        to_check.append(datetime.now(SampleTZInfo()))
-        datetime.add(datetime(2001, 1, 1, 23))
-        to_check.append(datetime.now())
-        to_check.append(datetime.now())
-        to_check.append(datetime.now(SampleTZInfo()))
-        datetime.set(d(2001, 1, 1, 22))
-        to_check.append(datetime.now())
-        datetime.add(d(2001, 1, 1, 23))
-        to_check.append(datetime.now())
-        to_check.append(datetime.now())
-        to_check.append(datetime.now(SampleTZInfo()))
+        dt_class = cast(type[MockDateTime], datetime)
+        to_check: list[datetime] = []
+        to_check.append(dt_class(1999, 1, 1))
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now(SampleTZInfo()))
+        to_check.append(dt_class.utcnow())
+        dt_class.set(2001, 1, 1, 20)
+        to_check.append(dt_class.now())
+        dt_class.add(2001, 1, 1, 21)
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now())
+        dt_class.set(datetime(2001, 1, 1, 22))
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now(SampleTZInfo()))
+        dt_class.add(datetime(2001, 1, 1, 23))
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now(SampleTZInfo()))
+        dt_class.set(d(2001, 1, 1, 22))
+        to_check.append(dt_class.now())
+        dt_class.add(d(2001, 1, 1, 23))
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now(SampleTZInfo()))
 
         for inst in to_check:
             self.assertTrue(isinstance(inst, datetime), inst)
@@ -368,54 +368,54 @@ class TestDateTime(TestCase):
             self.assertTrue(isinstance(inst, d), inst)
             self.assertFalse(inst.__class__ is d, inst)
 
-    def test_strict_addition(self):
+    def test_strict_addition(self) -> None:
         mock_dt = mock_datetime(strict=True)
         dt = mock_dt(2001, 1, 1) + timedelta(days=1)
         assert type(dt) is mock_dt
 
-    def test_non_strict_addition(self):
+    def test_non_strict_addition(self) -> None:
         from datetime import datetime
         mock_dt = mock_datetime(strict=False)
         dt = mock_dt(2001, 1, 1) + timedelta(days=1)
         assert type(dt) is datetime
 
-    def test_strict_add(self):
+    def test_strict_add(self) -> None:
         mock_dt = mock_datetime(None, strict=True)
         mock_dt.add(2001, 1, 1)
         assert type(mock_dt.now()) is mock_dt
 
-    def test_non_strict_add(self):
+    def test_non_strict_add(self) -> None:
         from datetime import datetime
         mock_dt = mock_datetime(None, strict=False)
         mock_dt.add(2001, 1, 1)
         assert type(mock_dt.now()) is datetime
 
     @replace('datetime.datetime', mock_datetime())
-    def test_isinstance_default(self):
+    def test_isinstance_default(self) -> None:
         from datetime import datetime
-        datetime = cast(type[MockDateTime], datetime)
-        to_check = []
-        to_check.append(datetime(1999, 1, 1))
-        to_check.append(datetime.now())
-        to_check.append(datetime.now(SampleTZInfo()))
-        to_check.append(datetime.utcnow())
-        datetime.set(2001, 1, 1, 20)
-        to_check.append(datetime.now())
-        datetime.add(2001, 1, 1, 21)
-        to_check.append(datetime.now())
-        to_check.append(datetime.now(SampleTZInfo()))
-        datetime.set(datetime(2001, 1, 1, 22))
-        to_check.append(datetime.now())
-        datetime.add(datetime(2001, 1, 1, 23))
-        to_check.append(datetime.now())
-        to_check.append(datetime.now())
-        to_check.append(datetime.now(SampleTZInfo()))
-        datetime.set(d(2001, 1, 1, 22))
-        to_check.append(datetime.now())
-        datetime.add(d(2001, 1, 1, 23))
-        to_check.append(datetime.now())
-        to_check.append(datetime.now())
-        to_check.append(datetime.now(SampleTZInfo()))
+        dt_class = cast(type[MockDateTime], datetime)
+        to_check: list[datetime] = []
+        to_check.append(dt_class(1999, 1, 1))
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now(SampleTZInfo()))
+        to_check.append(dt_class.utcnow())
+        dt_class.set(2001, 1, 1, 20)
+        to_check.append(dt_class.now())
+        dt_class.add(2001, 1, 1, 21)
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now(SampleTZInfo()))
+        dt_class.set(datetime(2001, 1, 1, 22))
+        to_check.append(dt_class.now())
+        dt_class.add(datetime(2001, 1, 1, 23))
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now(SampleTZInfo()))
+        dt_class.set(d(2001, 1, 1, 22))
+        to_check.append(dt_class.now())
+        dt_class.add(d(2001, 1, 1, 23))
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now())
+        to_check.append(dt_class.now(SampleTZInfo()))
 
         for inst in to_check:
             self.assertFalse(isinstance(inst, datetime), inst)
@@ -423,48 +423,48 @@ class TestDateTime(TestCase):
             self.assertTrue(isinstance(inst, d), inst)
             self.assertTrue(inst.__class__ is d, inst)
 
-    def test_subsecond_deltas(self):
+    def test_subsecond_deltas(self) -> None:
         datetime = mock_datetime(delta=0.5)
         compare(datetime.now(), datetime(2001, 1, 1, 0, 0, 0, 0))
         compare(datetime.now(), datetime(2001, 1, 1, 0, 0, 0, 500000))
         compare(datetime.now(), datetime(2001, 1, 1, 0, 0, 1, 0))
 
-    def test_ms_delta(self):
+    def test_ms_delta(self) -> None:
         datetime = mock_datetime(delta=100, delta_type='microseconds')
         compare(datetime.now(), datetime(2001, 1, 1, 0, 0, 0, 0))
         compare(datetime.now(), datetime(2001, 1, 1, 0, 0, 0, 100))
         compare(datetime.now(), datetime(2001, 1, 1, 0, 0, 0, 200))
 
-    def test_tick_when_static(self):
+    def test_tick_when_static(self) -> None:
         datetime = mock_datetime(delta=0)
         compare(datetime.now(), expected=d(2001, 1, 1))
         datetime.tick(hours=1)
         compare(datetime.now(), expected=d(2001, 1, 1, 1))
 
-    def test_tick_when_dynamic(self):
+    def test_tick_when_dynamic(self) -> None:
         # hopefully not that common?
         datetime = mock_datetime()
         compare(datetime.now(), expected=d(2001, 1, 1))
         datetime.tick(hours=1)
         compare(datetime.now(), expected=d(2001, 1, 1, 1, 0, 10))
 
-    def test_tick_with_timedelta_instance(self):
+    def test_tick_with_timedelta_instance(self) -> None:
         datetime = mock_datetime(delta=0)
         compare(datetime.now(), expected=d(2001, 1, 1))
         datetime.tick(timedelta(hours=1))
         compare(datetime.now(), expected=d(2001, 1, 1, 1))
 
-    def test_old_import(self):
+    def test_old_import(self) -> None:
         from testfixtures import test_datetime
         assert test_datetime is mock_datetime
 
-    def test_add_timedelta_not_strict(self):
+    def test_add_timedelta_not_strict(self) -> None:
         mock_class = mock_datetime()
         value = mock_class.now() + timedelta(seconds=10)
         assert isinstance(value, datetime)
         assert type(value) is datetime
 
-    def test_add_timedelta_strict(self):
+    def test_add_timedelta_strict(self) -> None:
         mock_class = mock_datetime(strict=True)
         value = mock_class.now() + timedelta(seconds=10)
         assert isinstance(value, datetime)

--- a/testfixtures/tests/test_time.py
+++ b/testfixtures/tests/test_time.py
@@ -9,19 +9,19 @@ from ..datetime import MockTime
 class TestTime(TestCase):
 
     @replace('time.time', mock_time())
-    def test_time_call(self):
+    def test_time_call(self) -> None:
         from time import time
         compare(time(), 978307200.0)
         compare(time(), 978307201.0)
         compare(time(), 978307203.0)
 
     @replace('time.time', mock_time(2002, 1, 1, 1, 2, 3))
-    def test_time_supplied(self):
+    def test_time_supplied(self) -> None:
         from time import time
         compare(time(), 1009846923.0)
 
     @replace('time.time', mock_time(None))
-    def test_time_sequence(self, t: type[MockTime]):
+    def test_time_sequence(self, t: type[MockTime]) -> None:
         t.add(2002, 1, 1, 1, 0, 0)
         t.add(2002, 1, 1, 2, 0, 0)
         t.add(2002, 1, 1, 3, 0, 0)
@@ -31,7 +31,7 @@ class TestTime(TestCase):
         compare(time(), 1009854000.0)
 
     @replace('time.time', mock_time(None))
-    def test_add_datetime_supplied(self, t: type[MockTime]):
+    def test_add_datetime_supplied(self, t: type[MockTime]) -> None:
         from datetime import datetime
         from time import time
         t.add(datetime(2002, 1, 1, 2))
@@ -44,13 +44,13 @@ class TestTime(TestCase):
             ))):
             t.add(datetime(2001, 1, 1, tzinfo=tzinfo))
 
-    def test_instantiate_with_datetime(self):
+    def test_instantiate_with_datetime(self) -> None:
         from datetime import datetime
         t = mock_time(datetime(2002, 1, 1, 2))
         compare(t(), 1009850400.0)
 
     @replace('time.time', mock_time(None))
-    def test_now_requested_longer_than_supplied(self, t: type[MockTime]):
+    def test_now_requested_longer_than_supplied(self, t: type[MockTime]) -> None:
         t.add(2002, 1, 1, 1, 0, 0)
         t.add(2002, 1, 1, 2, 0, 0)
         from time import time
@@ -60,42 +60,42 @@ class TestTime(TestCase):
         compare(time(), 1009850403.0)
 
     @replace('time.time', mock_time())
-    def test_call(self, t: type[MockTime]):
+    def test_call(self, t: type[MockTime]) -> None:
         compare(t(), 978307200.0)
         from time import time
         compare(time(), 978307201.0)
 
     @replace('time.time', mock_time())
-    def test_repr_time(self):
+    def test_repr_time(self) -> None:
         from time import time
         compare(repr(time), "<class 'testfixtures.datetime.MockTime'>")
 
     @replace('time.time', mock_time(delta=10))
-    def test_delta(self):
+    def test_delta(self) -> None:
         from time import time
         compare(time(), 978307200.0)
         compare(time(), 978307210.0)
         compare(time(), 978307220.0)
 
     @replace('time.time', mock_time(delta_type='minutes'))
-    def test_delta_type(self):
+    def test_delta_type(self) -> None:
         from time import time
         compare(time(), 978307200.0)
         compare(time(), 978307260.0)
         compare(time(), 978307380.0)
 
     @replace('time.time', mock_time(None))
-    def test_set(self):
+    def test_set(self) -> None:
         from time import time
-        time = cast(type[MockTime], time)
-        time.set(2001, 1, 1, 1, 0, 1)
+        time_func = cast(type[MockTime], time)
+        time_func.set(2001, 1, 1, 1, 0, 1)
         compare(time(), 978310801.0)
-        time.set(2002, 1, 1, 1, 0, 0)
+        time_func.set(2002, 1, 1, 1, 0, 0)
         compare(time(), 1009846800.0)
         compare(time(), 1009846802.0)
 
     @replace('time.time', mock_time(None))
-    def test_set_datetime_supplied(self, t: type[MockTime]):
+    def test_set_datetime_supplied(self, t: type[MockTime]) -> None:
         from datetime import datetime
         from time import time
         t.set(datetime(2001, 1, 1, 1, 0, 1))
@@ -109,60 +109,60 @@ class TestTime(TestCase):
             t.set(datetime(2001, 1, 1, tzinfo=tzinfo))
 
     @replace('time.time', mock_time(None))
-    def test_set_kw(self):
+    def test_set_kw(self) -> None:
         from time import time
-        time = cast(type[MockTime], time)
-        time.set(year=2001, month=1, day=1, hour=1, second=1)
+        time_func = cast(type[MockTime], time)
+        time_func.set(year=2001, month=1, day=1, hour=1, second=1)
         compare(time(), 978310801.0)
 
     @replace('time.time', mock_time(None))
-    def test_set_kw_tzinfo(self):
+    def test_set_kw_tzinfo(self) -> None:
         from time import time
-        time = cast(type[MockTime], time)
+        time_func = cast(type[MockTime], time)
         with ShouldRaise(TypeError('Cannot add using tzinfo on MockTime')):
-            time.set(year=2001, tzinfo=SampleTZInfo())
+            time_func.set(year=2001, tzinfo=SampleTZInfo())
 
     @replace('time.time', mock_time(None))
-    def test_set_args_tzinfo(self):
+    def test_set_args_tzinfo(self) -> None:
         from time import time
-        time = cast(type[MockTime], time)
+        time_func = cast(type[MockTime], time)
         with ShouldRaise(TypeError('Cannot add using tzinfo on MockTime')):
-            time.set(2002, 1, 2, 3, 4, 5, 6, SampleTZInfo())
+            time_func.set(2002, 1, 2, 3, 4, 5, 6, SampleTZInfo())
 
     @replace('time.time', mock_time(None))
-    def test_add_kw(self):
+    def test_add_kw(self) -> None:
         from time import time
-        time = cast(type[MockTime], time)
-        time.add(year=2001, month=1, day=1, hour=1, second=1)
+        time_func = cast(type[MockTime], time)
+        time_func.add(year=2001, month=1, day=1, hour=1, second=1)
         compare(time(), 978310801.0)
 
     @replace('time.time', mock_time(None))
-    def test_add_tzinfo_kw(self):
+    def test_add_tzinfo_kw(self) -> None:
         from time import time
-        time = cast(type[MockTime], time)
+        time_func = cast(type[MockTime], time)
         with ShouldRaise(TypeError('Cannot add using tzinfo on MockTime')):
-            time.add(year=2001, tzinfo=SampleTZInfo())
+            time_func.add(year=2001, tzinfo=SampleTZInfo())
 
     @replace('time.time', mock_time(None))
-    def test_add_tzinfo_args(self):
+    def test_add_tzinfo_args(self) -> None:
         from time import time
-        time = cast(type[MockTime], time)
+        time_func = cast(type[MockTime], time)
         with ShouldRaise(TypeError('Cannot add using tzinfo on MockTime')):
-            time.add(2001, 1, 2, 3, 4, 5, 6, SampleTZInfo())
+            time_func.add(2001, 1, 2, 3, 4, 5, 6, SampleTZInfo())
 
     @replace('time.time', mock_time(2001, 1, 2, 3, 4, 5, 600000))
-    def test_max_number_args(self):
+    def test_max_number_args(self) -> None:
         from time import time
         compare(time(), 978404645.6)
 
-    def test_max_number_tzinfo(self):
+    def test_max_number_tzinfo(self) -> None:
         with ShouldRaise(TypeError(
             "You don't want to use tzinfo with test_time"
                 )):
             mock_time(2001, 1, 2, 3, 4, 5, 6, SampleTZInfo())
 
     @replace('time.time', mock_time(2001, 1, 2))
-    def test_min_number_args(self):
+    def test_min_number_args(self) -> None:
         from time import time
         compare(time(), 978393600.0)
 
@@ -175,54 +175,54 @@ class TestTime(TestCase):
         second=5,
         microsecond=6,
         ))
-    def test_all_kw(self):
+    def test_all_kw(self) -> None:
         from time import time
         compare(time(), 978404645.000006)
 
-    def test_kw_tzinfo(self):
+    def test_kw_tzinfo(self) -> None:
         with ShouldRaise(TypeError(
             "You don't want to use tzinfo with test_time"
                 )):
             mock_time(year=2001, tzinfo=SampleTZInfo())
 
-    def test_instance_tzinfo(self):
+    def test_instance_tzinfo(self) -> None:
         from datetime import datetime
         with ShouldRaise(TypeError(
             "You don't want to use tzinfo with test_time"
                 )):
             mock_time(datetime(2001, 1, 1, tzinfo=SampleTZInfo()))
 
-    def test_subsecond_deltas(self):
+    def test_subsecond_deltas(self) -> None:
         time = mock_time(delta=0.5)
         compare(time(), 978307200.0)
         compare(time(), 978307200.5)
         compare(time(), 978307201.0)
 
-    def test_ms_deltas(self):
+    def test_ms_deltas(self) -> None:
         time = mock_time(delta=1000, delta_type='microseconds')
         compare(time(), 978307200.0)
         compare(time(), 978307200.001)
         compare(time(), 978307200.002)
 
-    def test_tick_when_static(self):
+    def test_tick_when_static(self) -> None:
         time = mock_time(delta=0)
         compare(time(), expected=978307200.0)
         time.tick(seconds=1)
         compare(time(), expected=978307201.0)
 
-    def test_tick_when_dynamic(self):
+    def test_tick_when_dynamic(self) -> None:
         # hopefully not that common?
         time = mock_time()
         compare(time(), expected=978307200.0)
         time.tick(seconds=1)
         compare(time(), expected=978307202.0)
 
-    def test_tick_with_timedelta_instance(self):
+    def test_tick_with_timedelta_instance(self) -> None:
         time = mock_time(delta=0)
         compare(time(), expected=978307200.0)
         time.tick(timedelta(seconds=1))
         compare(time(), expected=978307201.0)
 
-    def test_old_import(self):
+    def test_old_import(self) -> None:
         from testfixtures import test_time
         assert test_time is mock_time


### PR DESCRIPTION
Here's the chat:

https://chatgpt.com/codex/tasks/task_e_68639349b6688321bf4ba2312046f005